### PR TITLE
Exclude node_modules from conversion

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,7 @@ future: true
 # I normally exclude _sass, README*, and .gitignore
 # Directories that start with an underscore _ are not copied over by default. Still like to include _sass anyways.
 # ============================================================
-exclude: [README.md, Rakefile]
+exclude: [README.md, Rakefile, node_modules]
 
 # Pagination variable for how many posts to show in a list
 # ============================================================


### PR DESCRIPTION
So Jekyll doesn't start copying 15579 files into _site the first time you run it :)
