### PR TITLE
Change `pygments: true` to `highlighter: pygments`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,4 +49,4 @@ permalink: pretty
 
 # Uncomment if you have pygments installed. Used for code syntax highlighting.
 # If you're not doing syntax highlighting you can delete this.
-#pygments: true
+# highlighter: pygments


### PR DESCRIPTION
`pygments: true` has been [deprecated](http://jekyllrb.com/docs/templates/#code-snippet-highlighting) in favor of this new notation where you're able to choose between pygments and rouge. Noticed this yesterday while using this config file.