### PR TITLE
Replace invalid first character in configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@
 name: "NKD - Boilerplate for HTML5/SCSS projects."
 
 # Add your twitter handle (appears in site footer)
-twitter: @mrmrs_
+twitter: "@mrmrs_"
 
 # Add your email (appears in site footer)
 email: hi@mrmrs.cc

--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -1,6 +1,6 @@
 <footer class="pa3">
   <a class="link pr3 fw6" href="{{site.url}}">Home</a>
-  <a class="link pr3 fw6" href="{{site.twitter}}">Twitter</a>
-  <a class="link pr3 fw6" href="{{site.email}}">Email</a>
+  <a class="link pr3 fw6" href="https://twitter.com/{{site.twitter}}">Twitter</a>
+  <a class="link pr3 fw6" href="mailto:{{site.email}}">Email</a>
   <p class="mt2"><small>Copyright 2016</small></p>
 </footer>


### PR DESCRIPTION
##### What does this PR do?

Fixes some issues with the Jekyll configuration yml file that resulted in not being able to run `jekyll serve` in the V2 branch.

The "@" character can't be the first character in a yml configuration
value. So I replaced @ with ". This invalid character resulted in not
being able to run "jekyll serve" on jekyll 3.2.0.

I also changed the footer links so they work correctly with the values provided in the configuration file.
##### How should this be manually tested?
- Install jekyll 3.2.0 - `› gem install jekyll -v 3.2.0`
- run `npm instal`
- run `npm start` and confirm everything renders correctly
##### Any background context you want to provide?

I wanted to install the base project but I ran into some errors around sass (reported in https://github.com/mrmrs/nkd/issues/22) so I decided to help with releasing a postcss build. I found this issue while building the https://github.com/mrmrs/nkd/tree/v2 branch on which @mrmrs as been working on.
