### PR TITLE
Use bundler to enforce Ruby dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .ruby-version
 .ruby-gemset
-Gemfile.lock
 .sass-cache
 _site
 node_modules

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 3.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,40 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorator (1.1.0)
+    ffi (1.9.14)
+    forwardable-extended (2.6.0)
+    jekyll (3.2.1)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.11.1)
+    liquid (3.0.6)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.4.22)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (~> 3.2.0)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
   ],
   "license": "MIT",
   "scripts": {
-    "serve": "jekyll serve",
+    "postinstall": "bundle install",
+    "serve": "bundle exec jekyll serve",
     "build": "tachyons src/nkd.css > css/nkd.css && tachyons src/nkd.css --minify > css/nkd.min.css && tachyons src/nkd.css --generate-docs --package=../../package.json > readme.md",
     "watch": "watch 'npm run build' src/",
     "start": "parallelshell 'npm run serve' 'npm run watch'"


### PR DESCRIPTION
##### What does this PR do?

Adds bundler's Gemfile and Gemfile.lock so, that the Ruby dependencies have the correct version.

This helps make sure that the Jekyll version used matches the version
supported by Jekyll. This applies to Jekyll or any other future Ruby
dependencies. 

I Also added the installation of the ruby dependecies as a post install
step so, that is handled automatically when users to `npm install`.
##### How should this be manually tested?
- `rm -rf node_modules` (simulates a fresh install)
- `npm install` (to test that the ruby dependecies are installed correctly)
- `npm start` (starts the server)
##### Any background context you want to provide?

The goal is to avoid issues related to people having different versions installed on their machine.
At a later stage I wish to add a [Jekyll plugin for `livereload`](https://github.com/awood/hawkins) and this will ensure that also that plugin has the correct version.
