### PR TITLE
Change config to ease deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.2.0"
+gem "jekyll", "~> 3.1.6"
 
 group :jekyll_plugins do
   gem "hawkins", "~> 2.0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    colorator (1.1.0)
+    colorator (0.1)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.0.1)
     ffi (1.9.14)
-    forwardable-extended (2.6.0)
     hawkins (2.0.3)
       em-websocket (~> 0.5)
       jekyll (~> 3.1)
     http_parser.rb (0.6.0)
-    jekyll (3.2.1)
-      colorator (~> 1.0)
+    jekyll (3.1.6)
+      colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
       liquid (~> 3.0)
       mercenary (~> 0.3.3)
-      pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
     jekyll-sass-converter (1.4.0)
@@ -32,8 +30,6 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
-    pathutil (0.14.0)
-      forwardable-extended (~> 2.6)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -46,4 +42,4 @@ PLATFORMS
 
 DEPENDENCIES
   hawkins (~> 2.0.3)
-  jekyll (~> 3.2.0)
+  jekyll (~> 3.1.6)

--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ future: true
 # I normally exclude _sass, README*, and .gitignore
 # Directories that start with an underscore _ are not copied over by default. Still like to include _sass anyways.
 # ============================================================
-exclude: [README.md, node_modules, src]
+exclude: [README.md, node_modules, src, Gemfile, Gemfile.lock]
 
 # Pagination variable for how many posts to show in a list
 # ============================================================


### PR DESCRIPTION
##### What does this PR do?

Changes some configuration to make deployment easier. Namely:
- The previously installed version of Jekyll did not build on Heroku. So I changed nkd to use an older version of Jekyll
- Excluded some files related to dependency management from the `_site` directory (`Gemfile` and `Gemfile.lock`
##### How should this be manually tested?

For the Jekyll update
- I think it suffices to checkout the project and do a `bundle update jekyll` to ensure the new version is installed. (I deployed a site based on nkd to production a couple of days ago, so let's assume the deployment works)
- do an npm start and confirm the site still works

For the exclusion of Gefile
- `rm -rf _site`
- `npm start`
- confirm that `Gemfile`and `Gemfile.lock` aren't in `_site`
